### PR TITLE
[OneBot] Modify OneBotNode user_id type to be OneBot v11 compliant

### DIFF
--- a/Lagrange.OneBot/Core/Entity/Message/OneBotNode.cs
+++ b/Lagrange.OneBot/Core/Entity/Message/OneBotNode.cs
@@ -5,9 +5,9 @@ using Lagrange.OneBot.Message;
 namespace Lagrange.OneBot.Core.Entity.Message;
 
 [Serializable]
-public class OneBotNode(uint userId, string nickName, List<OneBotSegment> content) : SegmentBase
+public class OneBotNode(string userId, string nickName, List<OneBotSegment> content) : SegmentBase
 {
-    [JsonPropertyName("user_id")] public uint UserId { get; set; } = userId;
+    [JsonPropertyName("user_id")] public string UserId { get; set; } = userId;
 
     [JsonPropertyName("nickname")] public string NickName { get; set; } = nickName;
 

--- a/Lagrange.OneBot/Core/Operation/Message/GetForwardMsgOperation.cs
+++ b/Lagrange.OneBot/Core/Operation/Message/GetForwardMsgOperation.cs
@@ -27,7 +27,7 @@ public class GetForwardMsgOperation(MessageService service) : IOperation
                 var nickname = string.IsNullOrEmpty(chain.FriendInfo?.Nickname)
                     ? chain.GroupMemberInfo?.MemberName
                     : chain.FriendInfo?.Nickname;
-                var node = new OneBotNode(chain.FriendUin, nickname ?? "", parsed);
+                var node = new OneBotNode(chain.FriendUin.ToString(), nickname ?? "", parsed);
                 nodes.Add(new OneBotSegment("node", node));
             }
 


### PR DESCRIPTION
该pr需要被讨论！

当前`get_forward_msg`既不符合OneBot v11标准，也不符合常用的gocq事实标准

此Pr是为了符合ob11标准

[OneBot 11](https://github.com/botuniverse/onebot-11/blob/master/message/segment.md#%E5%90%88%E5%B9%B6%E8%BD%AC%E5%8F%91%E8%87%AA%E5%AE%9A%E4%B9%89%E8%8A%82%E7%82%B9)
在example中展示了，user_id的类型应该为string

[GOCQ](https://docs.go-cqhttp.org/api/#%E8%8E%B7%E5%8F%96%E5%90%88%E5%B9%B6%E8%BD%AC%E5%8F%91%E5%86%85%E5%AE%B9)
在example中展示了，user_id与nickname应包含在sender里，且user_id为int