### PR TITLE
[Chroe] Embedding the SilkCodec library into a binary

### DIFF
--- a/.github/workflows/Lagrange.OneBot-release.yml
+++ b/.github/workflows/Lagrange.OneBot-release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build Lagrange.OneBot .NET 8.0
         shell: powershell
         run: |
-          dotnet publish Lagrange.OneBot/Lagrange.OneBot.csproj --self-contained -p:PublishSingleFile=true -p:IncludeContentInSingleFile=true -p:RuntimeIdentifier=${{ matrix.runtimeIdentifier }} --framework net8.0
+          dotnet publish Lagrange.OneBot/Lagrange.OneBot.csproj --self-contained -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:RuntimeIdentifier=${{ matrix.runtimeIdentifier }} --framework net8.0
 
       - name: Upload binary files(${{ matrix.runtimeIdentifier }}) for .NET 8.0
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
> 感觉可以加个-p:IncludeNativeLibrariesForSelfExtract=true，把native assets包含在可执行文件里

From [#215 Comment](https://github.com/KonataDev/Lagrange.Core/pull/215#issuecomment-2005799600)

It runs fine after testing
