### PR TITLE
[OneBot] Fix unable to get private chat messages sent by bots (#219)

### DIFF
--- a/Lagrange.OneBot/Core/Operation/Message/SendPrivateMessageOperation.cs
+++ b/Lagrange.OneBot/Core/Operation/Message/SendPrivateMessageOperation.cs
@@ -28,6 +28,13 @@ public sealed class SendPrivateMessageOperation(LiteDatabase database, MessageCo
             Sequence = result.Sequence ?? 0,
             Time = DateTimeOffset.FromUnixTimeSeconds(result.Timestamp).DateTime,
             MessageId = chain.MessageId,
+            FriendInfo = new BotFriend(
+                context.BotUin,
+                string.Empty,
+                context.BotName ?? string.Empty,
+                string.Empty,
+                string.Empty
+            ),
             Entities = chain,
             MessageHash = MessageRecord.CalcMessageHash(chain.MessageId, result.Sequence ?? 0)
         };

--- a/Lagrange.OneBot/Core/Operation/Message/SendPrivateMessageOperation.cs
+++ b/Lagrange.OneBot/Core/Operation/Message/SendPrivateMessageOperation.cs
@@ -12,9 +12,12 @@ using LiteDB;
 namespace Lagrange.OneBot.Core.Operation.Message;
 
 [Operation("send_private_msg")]
-public sealed class SendPrivateMessageOperation(LiteDatabase database, MessageCommon common) : IOperation {
-    public async Task<OneBotResult> HandleOperation(BotContext context, JsonNode? payload) {
-        var chain = payload.Deserialize<OneBotPrivateMessageBase>(SerializerOptions.DefaultOptions) switch {
+public sealed class SendPrivateMessageOperation(LiteDatabase database, MessageCommon common) : IOperation
+{
+    public async Task<OneBotResult> HandleOperation(BotContext context, JsonNode? payload)
+    {
+        var chain = payload.Deserialize<OneBotPrivateMessageBase>(SerializerOptions.DefaultOptions) switch
+        {
             OneBotPrivateMessage message => common.ParseChain(message).Build(),
             OneBotPrivateMessageSimple messageSimple => common.ParseChain(messageSimple).Build(),
             OneBotPrivateMessageText messageText => common.ParseChain(messageText).Build(),
@@ -23,14 +26,15 @@ public sealed class SendPrivateMessageOperation(LiteDatabase database, MessageCo
 
         var result = await context.SendMessage(chain);
 
-        MessageRecord record = new() {
+        MessageRecord record = new()
+        {
             FriendUin = context.BotUin,
             Sequence = result.Sequence ?? 0,
             Time = DateTimeOffset.FromUnixTimeSeconds(result.Timestamp).DateTime,
             MessageId = chain.MessageId,
             FriendInfo = new BotFriend(
                 context.BotUin,
-                string.Empty,
+                context.ContextCollection.Keystore.Uid ?? string.Empty,
                 context.BotName ?? string.Empty,
                 string.Empty,
                 string.Empty

--- a/Lagrange.OneBot/Core/Operation/Message/SendPrivateMessageOperation.cs
+++ b/Lagrange.OneBot/Core/Operation/Message/SendPrivateMessageOperation.cs
@@ -1,30 +1,38 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Lagrange.Core;
+using Lagrange.Core.Common.Entity;
 using Lagrange.Core.Common.Interface.Api;
 using Lagrange.OneBot.Core.Entity.Action;
 using Lagrange.OneBot.Core.Entity.Action.Response;
 using Lagrange.OneBot.Core.Operation.Converters;
 using Lagrange.OneBot.Database;
+using LiteDB;
 
 namespace Lagrange.OneBot.Core.Operation.Message;
 
 [Operation("send_private_msg")]
-public sealed class SendPrivateMessageOperation(MessageCommon common) : IOperation
-{
-    public async Task<OneBotResult> HandleOperation(BotContext context, JsonNode? payload)
-    {
-        var chain = payload.Deserialize<OneBotPrivateMessageBase>(SerializerOptions.DefaultOptions) switch
-        {
+public sealed class SendPrivateMessageOperation(LiteDatabase database, MessageCommon common) : IOperation {
+    public async Task<OneBotResult> HandleOperation(BotContext context, JsonNode? payload) {
+        var chain = payload.Deserialize<OneBotPrivateMessageBase>(SerializerOptions.DefaultOptions) switch {
             OneBotPrivateMessage message => common.ParseChain(message).Build(),
             OneBotPrivateMessageSimple messageSimple => common.ParseChain(messageSimple).Build(),
             OneBotPrivateMessageText messageText => common.ParseChain(messageText).Build(),
             _ => throw new Exception()
         };
-        
+
         var result = await context.SendMessage(chain);
-        int hash = MessageRecord.CalcMessageHash(chain.MessageId, result.Sequence ?? 0);
-        
-        return new OneBotResult(new OneBotMessageResponse(hash), (int)result.Result, "ok");
+
+        MessageRecord record = new() {
+            FriendUin = context.BotUin,
+            Sequence = result.Sequence ?? 0,
+            Time = DateTimeOffset.FromUnixTimeSeconds(result.Timestamp).DateTime,
+            MessageId = chain.MessageId,
+            Entities = chain,
+            MessageHash = MessageRecord.CalcMessageHash(chain.MessageId, result.Sequence ?? 0)
+        };
+        database.GetCollection<MessageRecord>().Insert(new BsonValue(record.MessageHash), record);
+
+        return new OneBotResult(new OneBotMessageResponse(record.MessageHash), (int)result.Result, "ok");
     }
 }


### PR DESCRIPTION
Fix #219 

Constructs a `MessageRecord` and adds it to the database when sending a private chat message.