### PR TITLE
[OneBot] `get_msg` can't get `sender` information (#220)

### DIFF
--- a/Lagrange.Core/Common/Entity/BotFriend.cs
+++ b/Lagrange.Core/Common/Entity/BotFriend.cs
@@ -12,26 +12,28 @@ public class BotFriend
         Nickname = string.Empty;
         Remarks = string.Empty;
         PersonalSign = string.Empty;
+        Avatar = $"https://q1.qlogo.cn/g?b=qq&nk={Uin}&s=640";
     }
-    
-    internal BotFriend(uint uin,string uid, string nickname, string remarks, string personalSign)
+
+    internal BotFriend(uint uin, string uid, string nickname, string remarks, string personalSign)
     {
         Uin = uin;
         Uid = uid;
         Nickname = nickname;
         Remarks = remarks;
         PersonalSign = personalSign;
+        Avatar = $"https://q1.qlogo.cn/g?b=qq&nk={Uin}&s=640";
     }
-    
-    public uint Uin { get; }
-    
-    internal string Uid { get; }
-    
-    public string Nickname { get; }
-    
-    public string Remarks { get; }
-    
-    public string PersonalSign { get; }
 
-    public string Avatar => $"https://q1.qlogo.cn/g?b=qq&nk={Uin}&s=640";
+    public uint Uin { get; set; }
+
+    internal string Uid { get; set; }
+
+    public string Nickname { get; set; }
+
+    public string Remarks { get; set; }
+
+    public string PersonalSign { get; set; }
+
+    public string Avatar { get; set; }
 }

--- a/Lagrange.OneBot/Core/Operation/Message/GetMessageOperation.cs
+++ b/Lagrange.OneBot/Core/Operation/Message/GetMessageOperation.cs
@@ -21,15 +21,15 @@ public class GetMessageOperation(LiteDatabase database, MessageService service) 
         {
             var record = database.GetCollection<MessageRecord>().FindById(getMsg.MessageId);
             var chain = (MessageChain)record;
-            var sender = chain.GroupMemberInfo != null
+            var sender = chain.IsGroup
                 ? new OneBotSender(chain.GroupMemberInfo?.Uin ?? 0, chain.GroupMemberInfo?.MemberName ?? string.Empty)
                 : new OneBotSender(chain.FriendInfo?.Uin ?? 0, chain.FriendInfo?.Nickname ?? string.Empty);
             var elements = service.Convert(chain);
             var response = new OneBotGetMessageResponse(chain.Time, chain.IsGroup ? "group" : "private", record.MessageHash, sender, elements);
-            
+
             return Task.FromResult(new OneBotResult(response, 0, "ok"));
         }
-        
+
         throw new Exception();
     }
 }

--- a/Lagrange.OneBot/Core/Operation/Message/GetMessageOperation.cs
+++ b/Lagrange.OneBot/Core/Operation/Message/GetMessageOperation.cs
@@ -21,9 +21,9 @@ public class GetMessageOperation(LiteDatabase database, MessageService service) 
         {
             var record = database.GetCollection<MessageRecord>().FindById(getMsg.MessageId);
             var chain = (MessageChain)record;
-            var sender = chain.GroupMemberInfo == null
+            var sender = chain.GroupMemberInfo != null
                 ? new OneBotSender(chain.GroupMemberInfo?.Uin ?? 0, chain.GroupMemberInfo?.MemberName ?? string.Empty)
-                : new OneBotSender(chain.FriendUin, chain.FriendInfo?.Nickname ?? string.Empty);
+                : new OneBotSender(chain.FriendInfo?.Uin ?? 0, chain.FriendInfo?.Nickname ?? string.Empty);
             var elements = service.Convert(chain);
             var response = new OneBotGetMessageResponse(chain.Time, chain.IsGroup ? "group" : "private", record.MessageHash, sender, elements);
             


### PR DESCRIPTION
Fix #220

From Feb. 15 to the present...