### PR TITLE
[OneBot] Fix sender of get_msg incorrect for certain conditions

### DIFF
--- a/Lagrange.OneBot/Core/Operation/Message/SendGroupMessageOperation.cs
+++ b/Lagrange.OneBot/Core/Operation/Message/SendGroupMessageOperation.cs
@@ -11,7 +11,7 @@ using LiteDB;
 namespace Lagrange.OneBot.Core.Operation.Message;
 
 [Operation("send_group_msg")]
-public sealed class SendGroupMessageOperation(MessageCommon common, LiteDatabase database) : IOperation
+public sealed class SendGroupMessageOperation(MessageCommon common) : IOperation
 {
     public async Task<OneBotResult> HandleOperation(BotContext context, JsonNode? payload)
     {
@@ -25,8 +25,6 @@ public sealed class SendGroupMessageOperation(MessageCommon common, LiteDatabase
         
         var result = await context.SendMessage(chain);
         int hash = MessageRecord.CalcMessageHash(chain.MessageId, result.Sequence ?? 0);
-        chain.Sequence = result.Sequence ?? 0;
-        database.GetCollection<MessageRecord>().Insert(hash, (MessageRecord)chain);
         
         return new OneBotResult(new OneBotMessageResponse(hash), (int)result.Result, "ok");
     }

--- a/Lagrange.OneBot/Core/Operation/Message/SendPrivateForwardOperation.cs
+++ b/Lagrange.OneBot/Core/Operation/Message/SendPrivateForwardOperation.cs
@@ -8,11 +8,12 @@ using Lagrange.OneBot.Core.Entity.Action;
 using Lagrange.OneBot.Core.Entity.Action.Response;
 using Lagrange.OneBot.Core.Operation.Converters;
 using Lagrange.OneBot.Database;
+using LiteDB;
 
 namespace Lagrange.OneBot.Core.Operation.Message;
 
 [Operation("send_private_forward_msg")]
-public class SendPrivateForwardOperation(MessageCommon common) : IOperation
+public class SendPrivateForwardOperation(MessageCommon common, LiteDatabase database) : IOperation
 {
     public async Task<OneBotResult> HandleOperation(BotContext context, JsonNode? payload)
     {
@@ -22,10 +23,29 @@ public class SendPrivateForwardOperation(MessageCommon common) : IOperation
 
             var multi = new MultiMsgEntity(null, [.. chains]);
             var chain = MessageBuilder.Friend(forward.UserId).Add(multi).Build();
-            var ret = await context.SendMessage(chain);
-            int hash = MessageRecord.CalcMessageHash(chain.MessageId, ret.Sequence ?? 0);
+            var result = await context.SendMessage(chain);
+            int hash = MessageRecord.CalcMessageHash(chain.MessageId, result.Sequence ?? 0);
 
-            return new OneBotResult(new OneBotForwardResponse(hash, multi.ResId ?? ""), (int)ret.Result, "ok");
+            database.GetCollection<MessageRecord>().Insert(hash, new()
+            {
+                FriendUin = context.BotUin,
+                GroupUin = 0,
+                Sequence = result.Sequence ?? 0,
+                Time = chain.Time,
+                MessageId = chain.MessageId,
+                FriendInfo = new(
+                    context.BotUin,
+                    context.ContextCollection.Keystore.Uid ?? string.Empty,
+                    context.BotName ?? string.Empty,
+                    string.Empty,
+                    string.Empty
+                ),
+                GroupMemberInfo = null,
+                Entities = chain,
+                MessageHash = hash
+            });
+
+            return new OneBotResult(new OneBotForwardResponse(hash, multi.ResId ?? ""), (int)result.Result, "ok");
         }
 
         throw new Exception();

--- a/Lagrange.OneBot/Core/Operation/Message/SendPrivateMessageOperation.cs
+++ b/Lagrange.OneBot/Core/Operation/Message/SendPrivateMessageOperation.cs
@@ -22,13 +22,29 @@ public sealed class SendPrivateMessageOperation(MessageCommon common, LiteDataba
             OneBotPrivateMessageText messageText => common.ParseChain(messageText).Build(),
             _ => throw new Exception()
         };
-        
+
         var result = await context.SendMessage(chain);
         int hash = MessageRecord.CalcMessageHash(chain.MessageId, result.Sequence ?? 0);
-        
-        chain.Sequence = result.Sequence ?? 0;
-        database.GetCollection<MessageRecord>().Insert(hash, (MessageRecord)chain);
-        
+
+        database.GetCollection<MessageRecord>().Insert(hash, new()
+        {
+            FriendUin = context.BotUin,
+            GroupUin = 0,
+            Sequence = result.Sequence ?? 0,
+            Time = chain.Time,
+            MessageId = chain.MessageId,
+            FriendInfo = new(
+                context.BotUin,
+                context.ContextCollection.Keystore.Uid ?? string.Empty,
+                context.BotName ?? string.Empty,
+                string.Empty,
+                string.Empty
+            ),
+            GroupMemberInfo = null,
+            Entities = chain,
+            MessageHash = hash
+        });
+
         return new OneBotResult(new OneBotMessageResponse(hash), (int)result.Result, "ok");
     }
 }


### PR DESCRIPTION
Fix #276 

The problem of not saving to the database exists only when private message is sent, so there is no need to save to the database when group message is sent.

Cannot modify some of the parameters of MessageChain, so new MessageRecord is used.

Can't get the signature of the Bot, use string.Empty for now.