### PR TITLE
[OneBot] Fix `count` parameter of `get_group_msg_history` not working as expected

### DIFF
--- a/Lagrange.OneBot/Core/Operation/Message/GetGroupMessageHistoryOperation.cs
+++ b/Lagrange.OneBot/Core/Operation/Message/GetGroupMessageHistoryOperation.cs
@@ -24,8 +24,8 @@ public class GetGroupMessageHistoryOperation(LiteDatabase database, MessageServi
                 ? collection.Find(x => x.GroupUin == history.GroupId).OrderByDescending(x => x.Time).First()
                 : collection.FindById(history.MessageId);
             var chain = (MessageChain)record;
-            
-            if (await context.GetGroupMessage(history.GroupId, (uint)(chain.Sequence - history.Count), chain.Sequence) is { } results)
+
+            if (await context.GetGroupMessage(history.GroupId, (uint)(chain.Sequence - history.Count + 1), chain.Sequence) is { } results)
             {
                 var messages = results
                     .Select(x => message.ConvertToGroupMsg(context.BotUin, x))
@@ -33,7 +33,7 @@ public class GetGroupMessageHistoryOperation(LiteDatabase database, MessageServi
                 return new OneBotResult(new OneBotGroupMsgHistoryResponse(messages), 0, "ok");
             }
         }
-        
+
         throw new Exception();
     }
 }


### PR DESCRIPTION
Fix #282 