### PR TITLE
Solve image reading error under multiple bots

### DIFF
--- a/Lagrange.OneBot/Message/Entity/CommonResolver.cs
+++ b/Lagrange.OneBot/Message/Entity/CommonResolver.cs
@@ -27,7 +27,7 @@ public static class CommonResolver
         return uri.Scheme switch
         {
             "http" or "https" => Client.GetAsync(uri).Result.Content.ReadAsStreamAsync().Result,
-            "file" => new FileStream(Path.GetFullPath(uri.LocalPath), FileMode.Open),
+            "file" => new FileStream(Path.GetFullPath(uri.LocalPath), FileMode.Open, FileAccess.Read, FileShare.Read),
             _ => null,
         };
     }


### PR DESCRIPTION
Change the image file read permission mode to `FileShare.Read`


```log
warn: Lagrange.OneBot.Core.Operation.OperationService[0]
      Unexpected error encountered while handling message.
      System.IO.IOException: The process cannot access the file 'E:\Server\*\32860d5e-c3c0-4ff0-89be-f4613ada188a.jpg' because it is being used by another process.
         at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
         at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
         at System.IO.Strategies.OSFileStreamStrategy..ctor(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
         at System.IO.Strategies.FileStreamHelpers.ChooseStrategyCore(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
         at System.IO.FileStream..ctor(String path, FileMode mode)
         at Lagrange.OneBot.Message.Entity.CommonResolver.ResolveStream(String url)
         at Lagrange.OneBot.Message.Entity.ImageSegment.Build(MessageBuilder builder, SegmentBase segment)
         at Lagrange.OneBot.Core.Operation.Message.MessageCommon.BuildMessages(MessageBuilder builder, List`1 segments)
         at Lagrange.OneBot.Core.Operation.Message.MessageCommon.ParseChain(OneBotMessage message)
         at Lagrange.OneBot.Core.Operation.Message.SendMessageOperation.HandleOperation(BotContext context, JsonNode payload)
         at Lagrange.OneBot.Core.Operation.OperationService.HandleOperation(MsgRecvEventArgs e)
```