### PR TITLE
[OneBot] Better and compatible supports for Network Services.

### DIFF
--- a/Lagrange.OneBot/Core/Network/Options/HttpPostServiceOptions.cs
+++ b/Lagrange.OneBot/Core/Network/Options/HttpPostServiceOptions.cs
@@ -6,5 +6,7 @@ public sealed class HttpPostServiceOptions : HttpServiceOptions
 
     public uint HeartBeatInterval { get; set; } = 5000;
 
+    public bool HeartBeatEnable { get; set; } = true;
+
     public string Secret { get; set; } = string.Empty;
 }

--- a/Lagrange.OneBot/Core/Network/Options/WSServiceOptions.cs
+++ b/Lagrange.OneBot/Core/Network/Options/WSServiceOptions.cs
@@ -8,5 +8,7 @@ public abstract class WSServiceOptions
 
     public uint HeartBeatInterval { get; set; } = 5000; // by default 5000
 
+    public bool HeartBeatEnable { get; set; } = true;
+
     public string? AccessToken { get; set; }
 }

--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Please use Lagrange.Core responsibly and in accordance with the law.
       "Suffix": "/onebot/v11/ws",
       "ReconnectInterval": 5000,
       "HeartBeatInterval": 5000,
+      "HeartBeatEnable": true,
       "AccessToken": ""
     },
     {
@@ -320,6 +321,7 @@ Please use Lagrange.Core responsibly and in accordance with the law.
       "Host": "*",
       "Port": 8081,
       "HeartBeatInterval": 5000,
+      "HeartBeatEnable": true,
       "AccessToken": ""
     },
     {
@@ -328,6 +330,7 @@ Please use Lagrange.Core responsibly and in accordance with the law.
       "Port": 8082,
       "Suffix": "/",
       "HeartBeatInterval": 5000,
+      "HeartBeatEnable": true,
       "AccessToken": ""
     },
     {

--- a/README_zh.md
+++ b/README_zh.md
@@ -317,6 +317,7 @@ Please use Lagrange.Core responsibly and in accordance with the law.
       "Suffix": "/onebot/v11/ws",
       "ReconnectInterval": 5000,
       "HeartBeatInterval": 5000,
+      "HeartBeatEnable": true,
       "AccessToken": ""
     },
     {
@@ -324,6 +325,7 @@ Please use Lagrange.Core responsibly and in accordance with the law.
       "Host": "*",
       "Port": 8081,
       "HeartBeatInterval": 5000,
+      "HeartBeatEnable": true,
       "AccessToken": ""
     },
     {
@@ -332,6 +334,7 @@ Please use Lagrange.Core responsibly and in accordance with the law.
       "Port": 8082,
       "Suffix": "/",
       "HeartBeatInterval": 5000,
+      "HeartBeatEnable": true,
       "AccessToken": ""
     },
     {


### PR DESCRIPTION
Details about this commit:
﻿
1. ForwardWSService now won't sending ultra fast heartbeat when HeartBeatInterval == 0.
2. Following [OneBot v11 protocol](https://github.com/botuniverse/onebot-11/blob/master/event/meta.md#%E7%9B%B8%E5%85%B3%E9%85%8D%E7%BD%AE), add option `HeartBeatEnable` to make options more user-friendly.
3. Following [OneBot v11 protocol](https://github.com/botuniverse/onebot-11/blob/master/event/meta.md#%E7%94%9F%E5%91%BD%E5%91%A8%E6%9C%9F), ReverseWSService now also sending Connect Lifecycle MetaEvent.
4. ReverseWSService and HTTP POST now use more precise heartbeat intervals.
5. Project readme documents updated.
﻿

**This commit is compatible with past network services**. If this pull request accepted, I'll also open a pull request to update `Lagrange.Doc` .