### PR TITLE
[Core] lazy initialization of streams

### DIFF
--- a/Lagrange.Core/Internal/Context/Uploader/ImageUploader.cs
+++ b/Lagrange.Core/Internal/Context/Uploader/ImageUploader.cs
@@ -32,17 +32,17 @@ internal class ImageUploader : IHighwayUploader
                 };
                 var extStream = extend.Serialize();
 
-                bool hwSuccess = await context.Highway.UploadSrcByStreamAsync(1003, image.ImageStream, await Common.GetTicket(context), index.Info.FileHash.UnHex(), extStream.ToArray());
+                bool hwSuccess = await context.Highway.UploadSrcByStreamAsync(1003, image.ImageStream.Value, await Common.GetTicket(context), index.Info.FileHash.UnHex(), extStream.ToArray());
                 if (!hwSuccess)
                 {
-                    await image.ImageStream.DisposeAsync();
+                    await image.ImageStream.Value.DisposeAsync();
                     throw new Exception();
                 }
             }
             
             image.MsgInfo = metaResult.MsgInfo;  // directly constructed by Tencent's BDH Server
             image.CompatImage = metaResult.Compat;  // for legacy QQ
-            await image.ImageStream.DisposeAsync();
+            await image.ImageStream.Value.DisposeAsync();
         }
     }
 
@@ -68,17 +68,17 @@ internal class ImageUploader : IHighwayUploader
                 };
                 var extStream = extend.Serialize();
 
-                bool hwSuccess = await context.Highway.UploadSrcByStreamAsync(1004, image.ImageStream, await Common.GetTicket(context), index.Info.FileHash.UnHex(), extStream.ToArray());
+                bool hwSuccess = await context.Highway.UploadSrcByStreamAsync(1004, image.ImageStream.Value, await Common.GetTicket(context), index.Info.FileHash.UnHex(), extStream.ToArray());
                 if (!hwSuccess)
                 {
-                    await image.ImageStream.DisposeAsync();
+                    await image.ImageStream.Value.DisposeAsync();
                     throw new Exception();
                 }
             }
             
             image.MsgInfo = metaResult.MsgInfo;  // directly constructed by Tencent's BDH Server
             image.CompatFace = metaResult.Compat;  // for legacy QQ
-            await image.ImageStream.DisposeAsync();
+            await image.ImageStream.Value.DisposeAsync();
         }
     }
 }

--- a/Lagrange.Core/Internal/Context/Uploader/PttUploader.cs
+++ b/Lagrange.Core/Internal/Context/Uploader/PttUploader.cs
@@ -33,17 +33,17 @@ internal class PttUploader : IHighwayUploader
                 };
                 var extStream = extend.Serialize();
 
-                bool hwSuccess = await context.Highway.UploadSrcByStreamAsync(1007, record.AudioStream, await Common.GetTicket(context), index.Info.FileHash.UnHex(), extStream.ToArray());
+                bool hwSuccess = await context.Highway.UploadSrcByStreamAsync(1007, record.AudioStream.Value, await Common.GetTicket(context), index.Info.FileHash.UnHex(), extStream.ToArray());
                 if (!hwSuccess)
                 {
-                    await record.AudioStream.DisposeAsync();
+                    await record.AudioStream.Value.DisposeAsync();
                     throw new Exception();
                 }
             }
 
             record.MsgInfo = metaResult.MsgInfo;  // directly constructed by Tencent's BDH Server
             record.Compat = metaResult.Compat;  // for legacy QQ
-            await record.AudioStream.DisposeAsync();
+            await record.AudioStream.Value.DisposeAsync();
         }
     }
 
@@ -69,17 +69,17 @@ internal class PttUploader : IHighwayUploader
                 };
                 var extStream = extend.Serialize();
 
-                bool hwSuccess = await context.Highway.UploadSrcByStreamAsync(1008, record.AudioStream, await Common.GetTicket(context), index.Info.FileHash.UnHex(), extStream.ToArray());
+                bool hwSuccess = await context.Highway.UploadSrcByStreamAsync(1008, record.AudioStream.Value, await Common.GetTicket(context), index.Info.FileHash.UnHex(), extStream.ToArray());
                 if (!hwSuccess)
                 {
-                    await record.AudioStream.DisposeAsync();
+                    await record.AudioStream.Value.DisposeAsync();
                     throw new Exception();
                 }
             }
             
             record.MsgInfo = metaResult.MsgInfo;  // directly constructed by Tencent's BDH Server
             record.Compat = metaResult.Compat;  // for legacy QQ
-            await record.AudioStream.DisposeAsync();
+            await record.AudioStream.Value.DisposeAsync();
         }
     }
 }

--- a/Lagrange.Core/Internal/Context/Uploader/VideoUploader.cs
+++ b/Lagrange.Core/Internal/Context/Uploader/VideoUploader.cs
@@ -31,17 +31,17 @@ internal class VideoUploader : IHighwayUploader
                 };
                 var extStream = extend.Serialize();
 
-                bool hwSuccess = await context.Highway.UploadSrcByStreamAsync(1001, stream, await Common.GetTicket(context), index.Info.FileHash.UnHex(), extStream.ToArray());
+                bool hwSuccess = await context.Highway.UploadSrcByStreamAsync(1001, stream.Value, await Common.GetTicket(context), index.Info.FileHash.UnHex(), extStream.ToArray());
                 if (!hwSuccess)
                 {
-                    await stream.DisposeAsync();
+                    await stream.Value.DisposeAsync();
                     throw new Exception();
                 }
             }
 
             video.MsgInfo = metaResult.MsgInfo; // directly constructed by Tencent's BDH Server
             video.Compat = metaResult.Compat; // for legacy QQ
-            await stream.DisposeAsync();
+            await stream.Value.DisposeAsync();
         }
     }
 
@@ -63,21 +63,21 @@ internal class VideoUploader : IHighwayUploader
                     Network = Common.Convert(metaResult.Network),
                     MsgInfoBody = metaResult.MsgInfo.MsgInfoBody,
                     BlockSize = 1024 * 1024,
-                    Hash = new NTHighwayHash { FileSha1 = Common.CalculateStreamBytes(stream) }
+                    Hash = new NTHighwayHash { FileSha1 = Common.CalculateStreamBytes(stream.Value) }
                 };
                 var extStream = extend.Serialize();
 
-                bool hwSuccess = await context.Highway.UploadSrcByStreamAsync(1005, stream, await Common.GetTicket(context), index.Info.FileHash.UnHex(), extStream.ToArray());
+                bool hwSuccess = await context.Highway.UploadSrcByStreamAsync(1005, stream.Value, await Common.GetTicket(context), index.Info.FileHash.UnHex(), extStream.ToArray());
                 if (!hwSuccess)
                 {
-                    await stream.DisposeAsync();
+                    await stream.Value.DisposeAsync();
                     throw new Exception();
                 }
             }
             
             video.MsgInfo = metaResult.MsgInfo;  // directly constructed by Tencent's BDH Server
             video.Compat = metaResult.Compat;  // for legacy QQ
-            await stream.DisposeAsync();
+            await stream.Value.DisposeAsync();
         }
     }
 }

--- a/Lagrange.Core/Internal/Service/Message/ImageGroupUploadService.cs
+++ b/Lagrange.Core/Internal/Service/Message/ImageGroupUploadService.cs
@@ -22,11 +22,11 @@ internal class ImageGroupUploadService : BaseService<ImageGroupUploadEvent>
     {
         if (input.Entity.ImageStream is null) throw new Exception();
         
-        string md5 = input.Entity.ImageStream.Md5(true);
-        string sha1 = input.Entity.ImageStream.Sha1(true);
+        string md5 = input.Entity.ImageStream.Value.Md5(true);
+        string sha1 = input.Entity.ImageStream.Value.Sha1(true);
         
         var buffer = new byte[1024]; // parse image header
-        int _ = input.Entity.ImageStream.Read(buffer.AsSpan());
+        int _ = input.Entity.ImageStream.Value.Read(buffer.AsSpan());
         var type = ImageResolver.Resolve(buffer, out var size);
         string imageExt = type switch
         {
@@ -38,7 +38,7 @@ internal class ImageGroupUploadService : BaseService<ImageGroupUploadEvent>
             ImageFormat.Tiff => ".tiff",
             _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
         };
-        input.Entity.ImageStream.Position = 0;
+        input.Entity.ImageStream.Value.Position = 0;
 
         var packet = new OidbSvcTrpcTcpBase<NTV2RichMediaReq>(new NTV2RichMediaReq
         {
@@ -66,7 +66,7 @@ internal class ImageGroupUploadService : BaseService<ImageGroupUploadEvent>
                     {
                         FileInfo = new FileInfo
                         {
-                            FileSize = (uint)input.Entity.ImageStream.Length,
+                            FileSize = (uint)input.Entity.ImageStream.Value.Length,
                             FileHash = md5,
                             FileSha1 = sha1,
                             FileName = md5 + imageExt,

--- a/Lagrange.Core/Internal/Service/Message/ImageUploadService.cs
+++ b/Lagrange.Core/Internal/Service/Message/ImageUploadService.cs
@@ -22,11 +22,11 @@ internal class ImageUploadService : BaseService<ImageUploadEvent>
     {
         if (input.Entity.ImageStream is null) throw new Exception();
         
-        string md5 = input.Entity.ImageStream.Md5(true);
-        string sha1 = input.Entity.ImageStream.Sha1(true);
+        string md5 = input.Entity.ImageStream.Value.Md5(true);
+        string sha1 = input.Entity.ImageStream.Value.Sha1(true);
         
         var buffer = new byte[1024]; // parse image header
-        int _ = input.Entity.ImageStream.Read(buffer.AsSpan());
+        int _ = input.Entity.ImageStream.Value.Read(buffer.AsSpan());
         var type = ImageResolver.Resolve(buffer, out var size);
         string imageExt = type switch
         {
@@ -38,7 +38,7 @@ internal class ImageUploadService : BaseService<ImageUploadEvent>
             ImageFormat.Tiff => ".tiff",
             _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
         };
-        input.Entity.ImageStream.Position = 0;
+        input.Entity.ImageStream.Value.Position = 0;
 
         string uid = (string.IsNullOrEmpty(input.TargetUid) ? keystore.Uid : input.TargetUid) ?? "";
 
@@ -72,7 +72,7 @@ internal class ImageUploadService : BaseService<ImageUploadEvent>
                     {
                         FileInfo = new FileInfo
                         {
-                            FileSize = (uint)input.Entity.ImageStream.Length,
+                            FileSize = (uint)input.Entity.ImageStream.Value.Length,
                             FileHash = md5,
                             FileSha1 = sha1,
                             FileName = md5 + imageExt,

--- a/Lagrange.Core/Internal/Service/Message/RecordGroupUploadService.cs
+++ b/Lagrange.Core/Internal/Service/Message/RecordGroupUploadService.cs
@@ -21,8 +21,8 @@ internal class RecordGroupUploadService : BaseService<RecordGroupUploadEvent>
     {
         if (input.Entity.AudioStream is null) throw new Exception();
         
-        string md5 = input.Entity.AudioStream.Md5(true);
-        string sha1 = input.Entity.AudioStream.Sha1(true);
+        string md5 = input.Entity.AudioStream.Value.Md5(true);
+        string sha1 = input.Entity.AudioStream.Value.Sha1(true);
 
         var packet = new OidbSvcTrpcTcpBase<NTV2RichMediaReq>(new NTV2RichMediaReq
         {
@@ -50,7 +50,7 @@ internal class RecordGroupUploadService : BaseService<RecordGroupUploadEvent>
                     {
                         FileInfo = new FileInfo
                         {
-                            FileSize = (uint)input.Entity.AudioStream.Length,
+                            FileSize = (uint)input.Entity.AudioStream.Value.Length,
                             FileHash = md5,
                             FileSha1 = sha1,
                             FileName = md5 + ".amr",

--- a/Lagrange.Core/Internal/Service/Message/RecordUploadService.cs
+++ b/Lagrange.Core/Internal/Service/Message/RecordUploadService.cs
@@ -20,8 +20,8 @@ internal class RecordUploadService : BaseService<RecordUploadEvent>
     {
         if (input.Entity.AudioStream is null) throw new Exception();
         
-        string md5 = input.Entity.AudioStream.Md5(true);
-        string sha1 = input.Entity.AudioStream.Sha1(true);
+        string md5 = input.Entity.AudioStream.Value.Md5(true);
+        string sha1 = input.Entity.AudioStream.Value.Sha1(true);
 
         var packet = new OidbSvcTrpcTcpBase<NTV2RichMediaReq>(new NTV2RichMediaReq
         {
@@ -53,7 +53,7 @@ internal class RecordUploadService : BaseService<RecordUploadEvent>
                     {
                         FileInfo = new FileInfo
                         {
-                            FileSize = (uint)input.Entity.AudioStream.Length,
+                            FileSize = (uint)input.Entity.AudioStream.Value.Length,
                             FileHash = md5,
                             FileSha1 = sha1,
                             FileName = md5 + ".amr",

--- a/Lagrange.Core/Internal/Service/Message/VideoGroupUploadService.cs
+++ b/Lagrange.Core/Internal/Service/Message/VideoGroupUploadService.cs
@@ -21,8 +21,8 @@ internal class VideoGroupUploadService : BaseService<VideoGroupUploadEvent>
     {
         if (input.Entity.VideoStream is null) throw new Exception();
         
-        string md5 = input.Entity.VideoStream.Md5(true);
-        string sha1 = input.Entity.VideoStream.Sha1(true);
+        string md5 = input.Entity.VideoStream.Value.Md5(true);
+        string sha1 = input.Entity.VideoStream.Value.Sha1(true);
         
         var packet = new OidbSvcTrpcTcpBase<NTV2RichMediaReq>(new NTV2RichMediaReq
         {
@@ -50,7 +50,7 @@ internal class VideoGroupUploadService : BaseService<VideoGroupUploadEvent>
                     {
                         FileInfo = new FileInfo
                         {
-                            FileSize = (uint)input.Entity.VideoStream.Length,
+                            FileSize = (uint)input.Entity.VideoStream.Value.Length,
                             FileHash = md5,
                             FileSha1 = sha1,
                             FileName = "video.mp4",
@@ -72,7 +72,7 @@ internal class VideoGroupUploadService : BaseService<VideoGroupUploadEvent>
                     {
                         FileInfo = new FileInfo  // dummy images
                         {
-                            FileSize = (uint)input.Entity.VideoStream.Length - 1200,
+                            FileSize = (uint)input.Entity.VideoStream.Value.Length - 1200,
                             FileHash = md5,
                             FileSha1 = sha1,
                             FileName = "video.jpg",

--- a/Lagrange.Core/Internal/Service/Message/VideoUploadService.cs
+++ b/Lagrange.Core/Internal/Service/Message/VideoUploadService.cs
@@ -21,8 +21,8 @@ internal class VideoUploadService : BaseService<VideoUploadEvent>
     {
         if (input.Entity.VideoStream is null) throw new Exception();
         
-        string md5 = input.Entity.VideoStream.Md5(true);
-        string sha1 = input.Entity.VideoStream.Sha1(true);
+        string md5 = input.Entity.VideoStream.Value.Md5(true);
+        string sha1 = input.Entity.VideoStream.Value.Sha1(true);
         
         var packet = new OidbSvcTrpcTcpBase<NTV2RichMediaReq>(new NTV2RichMediaReq
         {
@@ -54,7 +54,7 @@ internal class VideoUploadService : BaseService<VideoUploadEvent>
                     {
                         FileInfo = new FileInfo
                         {
-                            FileSize = (uint)input.Entity.VideoStream.Length,
+                            FileSize = (uint)input.Entity.VideoStream.Value.Length,
                             FileHash = md5,
                             FileSha1 = sha1,
                             FileName = "video.mp4",
@@ -76,7 +76,7 @@ internal class VideoUploadService : BaseService<VideoUploadEvent>
                     {
                         FileInfo = new FileInfo  // dummy images
                         {
-                            FileSize = (uint)input.Entity.VideoStream.Length - 1200,
+                            FileSize = (uint)input.Entity.VideoStream.Value.Length - 1200,
                             FileHash = md5,
                             FileSha1 = sha1,
                             FileName = "video.jpg",

--- a/Lagrange.Core/Message/Entity/ImageEntity.cs
+++ b/Lagrange.Core/Message/Entity/ImageEntity.cs
@@ -25,7 +25,7 @@ public class ImageEntity : IMessageEntity
 
     public string ImageUrl { get; set; } = string.Empty;
 
-    internal Stream? ImageStream { get; set; }
+    internal Lazy<Stream>? ImageStream { get; set; }
 
     internal string? Path { get; set; }
 
@@ -42,19 +42,19 @@ public class ImageEntity : IMessageEntity
     public ImageEntity(string filePath)
     {
         FilePath = filePath;
-        ImageStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
+        ImageStream = new Lazy<Stream>(() => new FileStream(filePath, FileMode.Open, FileAccess.Read));
     }
 
     public ImageEntity(byte[] file)
     {
         FilePath = "";
-        ImageStream = new MemoryStream(file);
+        ImageStream = new Lazy<Stream>(() => new MemoryStream(file));
     }
     
     public ImageEntity(Stream stream)
     {
         FilePath = "";
-        ImageStream = stream;
+        ImageStream = new Lazy<Stream>(stream);
     }
 
     IEnumerable<Elem> IMessageEntity.PackElement()

--- a/Lagrange.Core/Message/Entity/RecordEntity.cs
+++ b/Lagrange.Core/Message/Entity/RecordEntity.cs
@@ -17,13 +17,13 @@ public class RecordEntity : IMessageEntity
 
     public string AudioName { get; set; } = string.Empty;
     
-    public int AudioSize { get; set; }
+    public int AudioSize => (int)AudioStream!.Value.Length;
     
     public string AudioUrl { get; set; } = string.Empty;
 
     #region Internal Properties
 
-    internal Stream? AudioStream { get; set; }
+    internal Lazy<Stream>? AudioStream { get; set; }
     
     internal string? AudioUuid { get; set; }
     
@@ -40,16 +40,14 @@ public class RecordEntity : IMessageEntity
     public RecordEntity(string filePath, int audioLength = 0)
     {
         FilePath = filePath;
-        AudioStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-        AudioSize = (int)AudioStream.Length;
+        AudioStream = new Lazy<Stream>(() => new FileStream(filePath, FileMode.Open, FileAccess.Read));
         AudioLength = audioLength;
     }
 
     public RecordEntity(byte[] file, int audioLength = 0)
     {
         FilePath = string.Empty;
-        AudioStream = new MemoryStream(file);
-        AudioSize = (int)AudioStream.Length;
+        AudioStream = new Lazy<Stream>(() => new MemoryStream(file));
         AudioLength = audioLength;
     }
 

--- a/Lagrange.Core/Message/Entity/VideoEntity.cs
+++ b/Lagrange.Core/Message/Entity/VideoEntity.cs
@@ -15,7 +15,7 @@ public class VideoEntity : IMessageEntity
 
     public Vector2 Size { get; }
 
-    public int VideoSize { get; }
+    public int VideoSize => (int)VideoStream!.Value.Length;
 
     public int VideoLength { get; set; }
 
@@ -23,7 +23,7 @@ public class VideoEntity : IMessageEntity
 
     #region Internal Properties
 
-    internal Stream? VideoStream { get; set; }
+    internal Lazy<Stream>? VideoStream { get; set; }
 
     internal string? VideoUuid { get; }
 
@@ -39,7 +39,6 @@ public class VideoEntity : IMessageEntity
     internal VideoEntity(Vector2 size, int videoSize, string filePath, string fileMd5, string videoUuid)
     {
         Size = size;
-        VideoSize = videoSize;
         FilePath = filePath;
         VideoHash = fileMd5;
         VideoUuid = videoUuid;
@@ -48,16 +47,14 @@ public class VideoEntity : IMessageEntity
     public VideoEntity(string filePath, int videoLength = 0)
     {
         FilePath = filePath;
-        VideoStream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
-        VideoSize = (int)VideoStream.Length;
+        VideoStream = new Lazy<Stream>(() => new FileStream(filePath, FileMode.Open, FileAccess.Read));
         VideoLength = videoLength;
     }
 
     public VideoEntity(byte[] file, int videoLength = 0)
     {
         FilePath = string.Empty;
-        VideoStream = new MemoryStream(file);
-        VideoSize = (int)VideoStream.Length;
+        VideoStream = new Lazy<Stream>(() => new MemoryStream(file));
         VideoLength = videoLength;
     }
 

--- a/Lagrange.OneBot/Message/Entity/ImageSegment.cs
+++ b/Lagrange.OneBot/Message/Entity/ImageSegment.cs
@@ -24,7 +24,7 @@ public partial class ImageSegment : SegmentBase
             builder.Add(new ImageEntity
             {
                 FilePath = "",
-                ImageStream = stream
+                ImageStream = new Lazy<Stream>(stream)
             });
         }
     }


### PR DESCRIPTION
Make stream initialization lazy, reducing overhead of message record deserialization & resolving possible `FileNotFoundException` & avoid unclosed stream
fixes #290 