### PR TITLE
[Core] Pref: Faster `Hex` function in `ByteExtension`

### DIFF
--- a/Lagrange.Core/Utility/Extension/ByteExtension.cs
+++ b/Lagrange.Core/Utility/Extension/ByteExtension.cs
@@ -1,30 +1,50 @@
-using System.Text;
 using System.Security.Cryptography;
 
 namespace Lagrange.Core.Utility.Extension;
 
 internal static class ByteExtension
 {
+    private static char[] lowerHexMap = new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+    private static char[] upperHexMap = new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
+
     public static string Hex(this byte[] bytes, bool lower = false, bool space = false)
-    {
-        var sb = new StringBuilder();
-        foreach (byte b in bytes)
-        {
-            sb.Append(b.ToString(lower ? "x2" : "X2"));
-            if (space) sb.Append(' ');
-        }
-        return sb.ToString();
-    }
-    
+        => Hex(bytes.AsSpan(), lower, space);
+
     public static string Hex(this Span<byte> bytes, bool lower = false, bool space = false)
+        => Hex((ReadOnlySpan<byte>)bytes, lower, space);
+
+    public static string Hex(this ReadOnlySpan<byte> bytes, bool lower = false, bool space = false)
+        => space ? HexWithSpace(bytes, lower) : HexNoSpace(bytes, lower);
+
+    public static string HexNoSpace(this ReadOnlySpan<byte> bytes, bool lower = false)
     {
-        var sb = new StringBuilder();
-        foreach (byte b in bytes)
+        Span<char> result = bytes.Length <= 1024 ? stackalloc char[bytes.Length * 2] : new char[bytes.Length * 2];
+        var map = lower ? lowerHexMap : upperHexMap;
+        byte mask = 0x0F;
+
+        for (var i = 0; i < bytes.Length; i++)
         {
-            sb.Append(b.ToString(lower ? "x2" : "X2"));
-            if (space) sb.Append(' ');
+            result[i * 2] = map[(bytes[i] >> 4) & mask];
+            result[i * 2 + 1] = map[bytes[i] & mask];
         }
-        return sb.ToString();
+
+        return new string(result);
+    }
+
+    public static string HexWithSpace(this ReadOnlySpan<byte> bytes, bool lower = false)
+    {
+        Span<char> result = bytes.Length <= 512 ? stackalloc char[bytes.Length * 3] : new char[bytes.Length * 3];
+        byte mask = 0x0F;
+        var map = lower ? lowerHexMap : upperHexMap;
+
+        for (var i = 0; i < bytes.Length; i++)
+        {
+            result[i * 2] = map[(bytes[i] >> 4) & mask];
+            result[i * 2 + 1] = map[bytes[i] & mask];
+            result[i * 2 + 2] = ' ';
+        }
+
+        return new string(result.Slice(0, Math.Max(0, result.Length - 1)));
     }
 
     public static string Md5(this byte[] bytes, bool lower = false)


### PR DESCRIPTION
## Here are the benchmark result
![image](https://github.com/KonataDev/Lagrange.Core/assets/42267840/6d9adc5c-5a54-4a20-9122-9b09a8f1a1cb)
[BenchmarkLog](https://github.com/KonataDev/Lagrange.Core/files/15142962/HexImplementation-20240429-004051.log)

## benchmark code
<details>

```CSharp
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

using System.Text;

var summary = BenchmarkRunner.Run<HexImplementation>();

[MemoryDiagnoser]
public class HexImplementation
{
    private byte[] data;

    [Params(16, 32, 128, 512, 2048)]
    public int N;

    [GlobalSetup]
    public void Setup()
    {
        data = new byte[N];
        new Random(0721).NextBytes(data);
    }

    [Benchmark]
    public void NewHex() => NewByteExtension.Hex(data, false);

    [Benchmark(Baseline = true)]
    public void OldHexArray() => OldByteExtension.Hex(data, false);

    [Benchmark]
    public void OldHexSpan() => OldByteExtension.Hex(data.AsSpan(), false);
}


public static class NewByteExtension
{
    private static char[] lowerHexMap = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'];
    private static char[] upperHexMap = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'];

    public static string Hex(this byte[] bytes, bool lower = false)
        => Hex(bytes.AsSpan(), lower);

    public static string Hex(this Span<byte> bytes, bool lower = false)
        => Hex((ReadOnlySpan<byte>)bytes, lower);

    public static string Hex(this ReadOnlySpan<byte> bytes, bool lower = false)
    {
        Span<char> result = bytes.Length <= 512 ? stackalloc char[bytes.Length * 2] : new char[bytes.Length * 2];
        byte mask = 0x0F;
        var map = lower ? lowerHexMap : upperHexMap;

        for (var i = 0; i < bytes.Length; i++)
        {
            result[i * 2] = map[(bytes[i] >> 4) & mask];
            result[i * 2 + 1] = map[bytes[i] & mask];
        }

        return new string(result);
    }
}

public static class OldByteExtension
{
    public static string Hex(this byte[] bytes, bool lower = false)
    {
        var sb = new StringBuilder();
        foreach (byte b in bytes)
        {
            sb.Append(b.ToString(lower ? "x2" : "X2"));
        }
        return sb.ToString();
    }

    public static string Hex(this Span<byte> bytes, bool lower = false)
    {
        var sb = new StringBuilder();
        foreach (byte b in bytes)
        {
            sb.Append(b.ToString(lower ? "x2" : "X2"));
        }
        return sb.ToString();
    }
}
```

</details>